### PR TITLE
Add spouse toggle for multiple-marriage records

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -14,9 +14,12 @@
 </head>
 <body>
 <h1>Evans Family Tree</h1>
-<input id="search" type="text" placeholder="Search for a family member" />
-<button id="searchBtn">Search</button>
+  <input id="search" type="text" placeholder="Search for a family member" />
+  <button id="searchBtn">Search</button>
   <div id="results"></div>
+  <label id="spouseLabel" style="display:none">Spouse:
+    <select id="spouseSelect"></select>
+  </label>
   <div id="tree"></div>
   <p>By default the first person in the data is displayed. Use the search above to jump to a relative.</p>
   <script src="script.js"></script>

--- a/webapp/script.js
+++ b/webapp/script.js
@@ -8,27 +8,67 @@ function searchNodes(nodes, query) {
   return nodes.filter(n => n.name && n.name.toLowerCase().includes(q));
 }
 
-function renderTree(nodes, rootId) {
+let allNodes = [];
+let currentRootId = null;
+let currentSpouseIndex = 0;
+
+function updateSpouseToggle(rootNode) {
+  const select = document.getElementById('spouseSelect');
+  const label = document.getElementById('spouseLabel');
+  select.innerHTML = '';
+
+  if (rootNode && rootNode.pids && rootNode.pids.length > 1) {
+    rootNode.pids.forEach((id, idx) => {
+      const spouse = allNodes.find(n => n.id === id);
+      const opt = document.createElement('option');
+      opt.value = idx;
+      opt.textContent = spouse ? spouse.name : id;
+      select.appendChild(opt);
+    });
+    label.style.display = 'inline';
+    select.value = currentSpouseIndex;
+    select.onchange = () => {
+      currentSpouseIndex = parseInt(select.value, 10);
+      renderTree(allNodes, currentRootId, currentSpouseIndex);
+    };
+  } else {
+    label.style.display = 'none';
+  }
+}
+
+function renderTree(nodesData, rootId, spouseIndex = 0) {
   document.getElementById('tree').innerHTML = '';
+  currentRootId = rootId;
+  currentSpouseIndex = spouseIndex;
+  allNodes = nodesData;
+
+  const displayNodes = allNodes.map(n => ({ ...n }));
+  const rootNode = displayNodes.find(n => n.id === rootId);
+  updateSpouseToggle(rootNode);
+
+  if (rootNode && rootNode.pids && rootNode.pids.length > 1) {
+    rootNode.pids = [rootNode.pids[spouseIndex]];
+  }
+
   new FamilyTree(document.getElementById('tree'), {
     template: 'john',
     nodeBinding: { field_0: 'name' },
-    nodes,
+    nodes: displayNodes,
     roots: [rootId]
   });
 }
 
 async function main() {
-  const nodes = await loadData();
+  const nodesData = await loadData();
   const searchBtn = document.getElementById('searchBtn');
   const searchInput = document.getElementById('search');
   const resultsDiv = document.getElementById('results');
 
-  const defaultId = nodes[0].id;
-  renderTree(nodes, defaultId);
+  const defaultId = nodesData[0].id;
+  renderTree(nodesData, defaultId);
 
   searchBtn.onclick = () => {
-    const results = searchNodes(nodes, searchInput.value);
+    const results = searchNodes(nodesData, searchInput.value);
     resultsDiv.innerHTML = '';
     if (results.length === 0) {
       resultsDiv.textContent = 'No matches found.';
@@ -37,7 +77,7 @@ async function main() {
     results.forEach(r => {
       const btn = document.createElement('button');
       btn.textContent = r.name;
-      btn.onclick = () => renderTree(nodes, r.id);
+      btn.onclick = () => renderTree(nodesData, r.id);
       resultsDiv.appendChild(btn);
     });
   };


### PR DESCRIPTION
## Summary
- add spouse selector UI to pick which spouse to display
- update tree rendering logic to show one spouse at a time

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c9b8c4bc0832692422feeac2e833c